### PR TITLE
Fixes #34, integrates with clarkson-core

### DIFF
--- a/query-monitor-twig-profile.php
+++ b/query-monitor-twig-profile.php
@@ -62,6 +62,7 @@ function collect_timber( Environment $twig ):Environment {
 }
 
 add_filter( 'timber/twig', __NAMESPACE__ . '\\collect_timber' );
+add_filter( 'clarkson_twig_environment', __NAMESPACE__ . '\\collect_timber' );
 
 /**
  * Adds twig profile collection to a Twig instance.

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,7 @@ Query Monitor Twig Profile data is private by default and always will be. It doe
 == Changelog ==
 1.3.0
 * Adds history mode. Save your profiles and view them later to see the impact of your changes. Compare profiles over multiple pages, and more.
+* Automatically integrates with clarkson-core:^1.0
 
 1.2.0
 * Adds blackfire.io profile downloads.

--- a/src/class-output.php
+++ b/src/class-output.php
@@ -64,7 +64,7 @@ final class Output extends QM_Output_Html {
 				echo '<div class="qm-boxed">';
 				echo '<section>';
 				?>
-				<p><?php echo esc_html__( 'No twig profiles on this page :)', 'ndb_qm_twig' ); ?></p>
+				<p><?php echo esc_html__( 'No twig profiles on this page :) If you are using twig on this page, check out the README to find out how to capture profiling information.', 'ndb_qm_twig' ); ?></p>
 				<?php
 				echo '</section>';
 				echo '</div>';


### PR DESCRIPTION
Also updates the 'no twig data found' message with a reference to the README, in case a profile could not be automatically captured.