### PR TITLE
Only enqueue scripts when necessary

### DIFF
--- a/query-monitor-twig-profile.php
+++ b/query-monitor-twig-profile.php
@@ -15,6 +15,7 @@
 namespace NdB\QM_Twig_Profile;
 
 use QM_Collectors;
+use QM_Dispatcher;
 use Twig\Environment;
 use Twig\Extension\ProfilerExtension;
 use Twig\Profiler\Profile;
@@ -91,6 +92,9 @@ function collect( Environment $twig ):Environment {
  * @return void
  */
 function enqueue_scripts() {
+	if ( ! QM_Dispatcher::user_can_view() ) {
+		return;
+	}
 	if ( ! function_exists( 'get_plugin_data' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}


### PR DESCRIPTION
The plugin currently enqueues scripts for all visitors of the site, including those who are not logged in and those who cannot view Query Monitor.

With this update, If the current user cannot view Query Monitor, there is an early return without enqueuing scripts.